### PR TITLE
Limits

### DIFF
--- a/src/cfasodapy/__init__.py
+++ b/src/cfasodapy/__init__.py
@@ -7,6 +7,23 @@ from urllib.parse import urlunparse
 import requests
 
 
+def _int_divide_ceiling(a: int, b: int) -> int:
+    """
+    Equivalent of a // b, but with
+    ceiling rather than floor behavior.
+
+    Follows the implementation here: https://stackoverflow.com/a/17511341
+
+    Args:
+        a (int): dividend
+        b (int): divisor
+
+    Returns:
+        int: (1 + a // b) if a is not divisible by b, otherwise (a // b)
+    """
+    return -(a // -b)
+
+
 class Query:
     def __init__(
         self,
@@ -87,11 +104,7 @@ class Query:
             Sequence of pages, each of which is a list of records
         """
 
-        starts = list(range(self._start_record, self._end_record, page_size))
-        ends = [s + 1 for s in starts[1:]] + [self._end_record]
-        assert len(starts) == len(ends)
-
-        n_pages = len(starts)
+        n_pages = _int_divide_ceiling(self.n_records, page_size)
 
         if self.verbose:
             print(
@@ -99,21 +112,32 @@ class Query:
                 f"{page_size} records each..."
             )
 
-        for i, (start, end) in enumerate(zip(starts, ends)):
-            if self.verbose:
-                print(f"  Downloading page {i + 1}/{n_pages}")
+        offset = self.offset
+        i = 1
+        page = None
 
-            page = self._get_records(start=start, end=end)
+        while page is None or len(page) == page_size:
+            page = self._get_page(offset=offset, limit=page_size)
 
-            assert (
-                len(page) == page_size
-            ), f"Expected page of size {page_size}, saw {len(page)}"
+            if len(page) > 0:
+                if self.verbose:
+                    print(f"  Downloaded page {i}/{n_pages} with {len(page)} records")
 
-            yield page
+                yield page
+                offset += page_size
+                i += 1
 
-    @functools.cached_property
-    def _n_where_records(self) -> int:
-        """Number of records in the dataset that satisfy the WHERE clause"""
+    def _get_page(self, offset: int, limit: int) -> list[dict]:
+        return self._get_request(
+            self.url,
+            params=self._build_payload(
+                select=self.select, where=self.where, offset=offset, limit=limit
+            ),
+            app_token=self.app_token,
+        )
+
+    def _get_n_where(self) -> int:
+        """Number of records that satisfy the WHERE clause"""
         result = self._get_request(
             self.url,
             params=self._build_payload(select="count(:id)", where=self.where, limit=1),
@@ -122,59 +146,29 @@ class Query:
 
         assert len(result) == 1, f"Expected length 1, got {len(result)}"
         assert "count_id" in result[0]
-        n = int(result[0]["count_id"])
+        return int(result[0]["count_id"])
 
-        if n == 0 and self.verbose:
-            warnings.warn(
-                f"Dataset {self.id} at {self.domain} has no records. "
-                "This may be due to an bad query."
-            )
+    @functools.cached_property
+    def n_records(self) -> int:
+        """Inferred number of records in the query"""
+        n_where = self._get_n_where()
 
-        return n
-
-    @property
-    def _start_record(self) -> int:
-        return min(self.offset, self._n_where_records - 1)
-
-    @property
-    def _end_record(self) -> int:
-        if self._n_where_records == 0:
+        if n_where == 0:
+            if self.verbose:
+                warnings.warn(
+                    "No records satisfy the WHERE clause. This may be due to an bad query."
+                )
+            return 0
+        elif self.offset >= n_where:
+            if self.verbose:
+                warnings.warn(
+                    "Offset is greater than number of records that satisfy WHERE clause."
+                )
             return 0
         elif self.limit is None:
-            return self._n_where_records - 1
+            return n_where - self.offset
         else:
-            return min(self._n_where_records - 1, self._start_record + self.limit - 1)
-
-    @property
-    def n_records(self) -> int:
-        """
-        The number of records in the query. If the query has zero offset, no limit, and no
-        WHERE clause, this is the number of records in the dataset.
-        """
-        return self._end_record - self._start_record
-
-    def _get_records(self, start: int, end: int) -> list[dict]:
-        """
-        Download a specific range of records that satisfy the WHERE clause
-
-        Args:
-            start: first record, zero-indexed
-            end: last record, zero-indexed
-
-        Returns:
-            records
-        """
-
-        assert start <= end
-        limit = end - start + 1
-
-        return self._get_request(
-            self.url,
-            params=self._build_payload(
-                select=self.select, where=self.where, offset=start, limit=limit
-            ),
-            app_token=self.app_token,
-        )
+            return min(n_where - self.offset, self.limit)
 
     @classmethod
     def _build_payload(

--- a/src/cfasodapy/__init__.py
+++ b/src/cfasodapy/__init__.py
@@ -1,5 +1,4 @@
 import functools
-import itertools
 import warnings
 from collections.abc import Iterator, Sequence
 from typing import Optional
@@ -88,12 +87,11 @@ class Query:
             Sequence of pages, each of which is a list of records
         """
 
-        starts = [self._start_record]
-        ends = []
-        x = self._start_record
-
         starts = list(range(self._start_record, self._end_record, page_size))
-        n_pages = len(starts) - 1
+        ends = [s + 1 for s in starts[1:]] + [self._end_record]
+        assert len(starts) == len(ends)
+
+        n_pages = len(starts)
 
         if self.verbose:
             print(
@@ -101,20 +99,16 @@ class Query:
                 f"{page_size} records each..."
             )
 
-        for i, (start, next_start) in enumerate(itertools.pairwise(starts)):
+        for i, (start, end) in enumerate(zip(starts, ends)):
             if self.verbose:
                 print(f"  Downloading page {i + 1}/{n_pages}")
 
-            page = self._get_records(start=start, end=next_start - 1)
+            page = self._get_records(start=start, end=end)
 
-            assert len(page) == page_size
+            assert (
+                len(page) == page_size
+            ), f"Expected page of size {page_size}, saw {len(page)}"
 
-            yield page
-
-        # partial, final page
-        if next_start - 1 < self._end_record:
-            page = self._get_records(start=next_start, end=self._end_record)
-            assert 0 < len(page) < page_size
             yield page
 
     @functools.cached_property

--- a/src/cfasodapy/__init__.py
+++ b/src/cfasodapy/__init__.py
@@ -1,26 +1,11 @@
+import functools
+import itertools
 import warnings
 from collections.abc import Iterator, Sequence
 from typing import Optional
 from urllib.parse import urlunparse
 
 import requests
-
-
-def _int_divide_ceiling(a: int, b: int) -> int:
-    """
-    Equivalent of a // b, but with
-    ceiling rather than floor behavior.
-
-    Follows the implementation here: https://stackoverflow.com/a/17511341
-
-    Args:
-        a (int): dividend
-        b (int): divisor
-
-    Returns:
-        int: (1 + a // b) if a is not divisible by b, otherwise (a // b)
-    """
-    return -(a // -b)
 
 
 class Query:
@@ -67,14 +52,14 @@ class Query:
 
     def get_all(self) -> list[dict]:
         """
-        Download all records from the dataset
+        Download all records from the query
 
         Returns:
             list[dict]: list of records
         """
 
         if self.verbose:
-            print(f"Downloading dataset {self.domain} {self.id}: {self.n_rows} rows")
+            print(f"Downloading {self.n_records} records")
 
         result = self._get_request(
             self.url,
@@ -88,7 +73,7 @@ class Query:
         )
 
         if self.verbose:
-            print(f"  Downloaded {len(result)} rows")
+            print(f"  Downloaded {len(result)} records")
 
         return result
 
@@ -97,53 +82,44 @@ class Query:
         Download a dataset page by page
 
         Args:
-            page_size (int): number of records per page (default: 10,000)
+            page_size: number of records per page
 
         Yields:
             Sequence of pages, each of which is a list of records
         """
 
-        if self.limit is None:
-            row_count = self.n_rows
-        else:
-            row_count = min(self.limit, self.n_rows)
+        starts = [self._start_record]
+        ends = []
+        x = self._start_record
 
-        n_pages = _int_divide_ceiling(row_count, page_size)
+        starts = list(range(self._start_record, self._end_record, page_size))
+        n_pages = len(starts) - 1
 
         if self.verbose:
             print(
-                f"Downloading dataset {self.domain} {self.id}: "
-                f"{row_count} rows in {n_pages} page(s) of at most "
-                f"{page_size} rows each..."
+                f"Downloading {self.n_records} records in {n_pages} page(s) of "
+                f"{page_size} records each..."
             )
 
-        for i in range(n_pages):
+        for i, (start, next_start) in enumerate(itertools.pairwise(starts)):
             if self.verbose:
                 print(f"  Downloading page {i + 1}/{n_pages}")
 
-            start = self.offset + i * page_size
+            page = self._get_records(start=start, end=next_start - 1)
 
-            # on the last page, only go up to the row count
-            if i + 1 == n_pages:
-                end = self.offset + row_count - 1
-            else:
-                end = self.offset + (i + 1) * page_size - 1
-
-            page = self._get_records(start=start, end=end)
-
-            assert len(page) > 0
-            assert len(page) <= page_size
+            assert len(page) == page_size
 
             yield page
 
-    @property
-    def n_rows(self) -> int:
-        """
-        The number of rows in the query
+        # partial, final page
+        if next_start - 1 < self._end_record:
+            page = self._get_records(start=next_start, end=self._end_record)
+            assert 0 < len(page) < page_size
+            yield page
 
-        Returns:
-            int: number of rows in the dataset
-        """
+    @functools.cached_property
+    def _n_where_records(self) -> int:
+        """Number of records in the dataset that satisfy the WHERE clause"""
         result = self._get_request(
             self.url,
             params=self._build_payload(select="count(:id)", where=self.where, limit=1),
@@ -152,57 +128,56 @@ class Query:
 
         assert len(result) == 1, f"Expected length 1, got {len(result)}"
         assert "count_id" in result[0]
-        n_dataset_rows = int(result[0]["count_id"])
+        n = int(result[0]["count_id"])
 
-        if n_dataset_rows == 0:
-            if self.verbose:
-                warnings.warn(
-                    f"Dataset {self.id} at {self.domain} has no rows. "
-                    "This may be due to an bad query."
-                )
+        if n == 0 and self.verbose:
+            warnings.warn(
+                f"Dataset {self.id} at {self.domain} has no records. "
+                "This may be due to an bad query."
+            )
+
+        return n
+
+    @property
+    def _start_record(self) -> int:
+        return min(self.offset, self._n_where_records - 1)
+
+    @property
+    def _end_record(self) -> int:
+        if self._n_where_records == 0:
             return 0
-
-        n_rows_after_offset = n_dataset_rows - self.offset
-
-        if n_rows_after_offset < 0:
-            if self.verbose:
-                warnings.warn(
-                    f"Offset {self.offset} is larger than the number of rows"
-                    f" in the dataset ({n_dataset_rows})."
-                )
-            return 0
-
-        if self.limit is None or self.limit > n_rows_after_offset:
-            return n_rows_after_offset
+        elif self.limit is None:
+            return self._n_where_records - 1
         else:
-            return n_rows_after_offset - self.limit
+            return min(self._n_where_records - 1, self._start_record + self.limit - 1)
+
+    @property
+    def n_records(self) -> int:
+        """
+        The number of records in the query. If the query has zero offset, no limit, and no
+        WHERE clause, this is the number of records in the dataset.
+        """
+        return self._end_record - self._start_record
 
     def _get_records(self, start: int, end: int) -> list[dict]:
         """
-        Download a specific range of rows from a query, accounting
-        for the offset and limit.
+        Download a specific range of records that satisfy the WHERE clause
 
         Args:
-            start (int): first row (zero-indexed)
-            end (int): last row (zero-indexed)
+            start: first record, zero-indexed
+            end: last record, zero-indexed
 
         Returns:
-            list[dict]: list of records
+            records
         """
 
-        assert end >= start
-        assert (
-            self.limit is None or end < self.limit
-        ), f"End index {end} is larger than limit {self.limit}."
-        n_rows = end - start + 1
+        assert start <= end
+        limit = end - start + 1
 
         return self._get_request(
             self.url,
             params=self._build_payload(
-                select=self.select,
-                where=self.where,
-                offset=self.offset + start,
-                limit=n_rows,
+                select=self.select, where=self.where, offset=start, limit=limit
             ),
             app_token=self.app_token,
         )

--- a/src/cfasodapy/__init__.py
+++ b/src/cfasodapy/__init__.py
@@ -103,7 +103,11 @@ class Query:
             Sequence of pages, each of which is a list of records
         """
 
-        row_count = self.n_rows
+        if self.limit is None:
+            row_count = self.n_rows
+        else:
+            row_count = min(self.limit, self.n_rows)
+
         n_pages = _int_divide_ceiling(row_count, page_size)
 
         if self.verbose:
@@ -117,8 +121,14 @@ class Query:
             if self.verbose:
                 print(f"  Downloading page {i + 1}/{n_pages}")
 
-            start = i * page_size
-            end = (i + 1) * page_size - 1
+            start = self.offset + i * page_size
+
+            # on the last page, only go up to the row count
+            if i + 1 == n_pages:
+                end = self.offset + row_count - 1
+            else:
+                end = self.offset + (i + 1) * page_size - 1
+
             page = self._get_records(start=start, end=end)
 
             assert len(page) > 0

--- a/tests/test_cfasodapy.py
+++ b/tests/test_cfasodapy.py
@@ -1,3 +1,5 @@
+import pytest
+
 from cfasodapy import Query
 
 
@@ -7,7 +9,7 @@ def test_build_url():
     """
     domain = "data.cdc.gov"
     id = "abc123"
-    expected_url = "https://data.cdc.gov/resource/abc123.json"
+    expected_url = f"https://{domain}/resource/{id}.json"
 
     assert Query(domain=domain, id=id).url == expected_url
 
@@ -24,3 +26,44 @@ def test_build_payload_select_list():
     expected_payload = {"$select": "field1,field2", "$offset": 0}
 
     assert Query._build_payload(select=select) == expected_payload
+
+
+@pytest.mark.parametrize(
+    ["offset", "limit", "expected_start", "expected_end"],
+    [
+        # assuming 10 records...
+        # cover the whole dataset
+        (0, None, 0, 9),
+        # get only 1 records
+        (0, 1, 0, 0),
+        # get only the first 2 records
+        (0, 2, 0, 1),
+        # skip 1 record, go to the end
+        (1, None, 1, 9),
+        # skip 5 records, try to go past the end, go to the end
+        (5, 100, 5, 9),
+        # skip many records; start & end at the end
+        (100, None, 9, 9),
+    ],
+)
+def test_start_end(monkeypatch, offset, limit, expected_start, expected_end):
+    monkeypatch.setattr(Query, "_n_where_records", 10)
+    q = Query(domain="data.cdc.gov", id="abc123", limit=limit, offset=offset)
+    assert q._start_record == expected_start
+    assert q._end_record == expected_end
+
+
+def test_pages(monkeypatch):
+    def mock_get_records(_, start, end):
+        return list(range(start, end + 1))
+
+    monkeypatch.setattr(Query, "_get_records", mock_get_records)
+    monkeypatch.setattr(Query, "_n_where_records", 100)
+
+    q = Query(domain="data.cdc.gov", id="abc123", offset=0, limit=None)
+    pages = list(q.get_pages(page_size=50))
+    assert len(pages) == 2
+    assert pages[0][0] == 0
+    assert pages[0][-1] == 49
+    assert pages[1][0] == 50
+    assert pages[1][-1] == 99

--- a/tests/test_cfasodapy.py
+++ b/tests/test_cfasodapy.py
@@ -1,5 +1,3 @@
-import pytest
-
 from cfasodapy import Query
 
 
@@ -28,37 +26,14 @@ def test_build_payload_select_list():
     assert Query._build_payload(select=select) == expected_payload
 
 
-@pytest.mark.parametrize(
-    ["offset", "limit", "expected_start", "expected_end"],
-    [
-        # assuming 10 records...
-        # cover the whole dataset
-        (0, None, 0, 9),
-        # get only 1 records
-        (0, 1, 0, 0),
-        # get only the first 2 records
-        (0, 2, 0, 1),
-        # skip 1 record, go to the end
-        (1, None, 1, 9),
-        # skip 5 records, try to go past the end, go to the end
-        (5, 100, 5, 9),
-        # skip many records; start & end at the end
-        (100, None, 9, 9),
-    ],
-)
-def test_start_end(monkeypatch, offset, limit, expected_start, expected_end):
-    monkeypatch.setattr(Query, "_n_where_records", 10)
-    q = Query(domain="data.cdc.gov", id="abc123", limit=limit, offset=offset)
-    assert q._start_record == expected_start
-    assert q._end_record == expected_end
+def test_pages_even(monkeypatch):
+    n_records = 100
 
+    def mock_get_page(_, offset, limit):
+        return list(range(offset, min(n_records, offset + limit)))
 
-def test_pages(monkeypatch):
-    def mock_get_records(_, start, end):
-        return list(range(start, end))
-
-    monkeypatch.setattr(Query, "_get_records", mock_get_records)
-    monkeypatch.setattr(Query, "_n_where_records", 100)
+    monkeypatch.setattr(Query, "_get_page", mock_get_page)
+    monkeypatch.setattr(Query, "n_records", n_records)
 
     q = Query(domain="data.cdc.gov", id="abc123", offset=0, limit=None)
     pages = list(q.get_pages(page_size=50))
@@ -67,3 +42,22 @@ def test_pages(monkeypatch):
     assert pages[0][-1] == 49
     assert pages[1][0] == 50
     assert pages[1][-1] == 99
+
+
+def test_pages_uneven(monkeypatch):
+    n_records = 100
+    page_size = 75
+
+    def mock_get_page(_, offset, limit):
+        return list(range(offset, min(n_records, offset + limit)))
+
+    monkeypatch.setattr(Query, "_get_page", mock_get_page)
+    monkeypatch.setattr(Query, "n_records", n_records)
+
+    q = Query(domain="data.cdc.gov", id="abc123", offset=0, limit=None)
+    pages = list(q.get_pages(page_size=page_size))
+    assert len(pages) == 2
+    assert pages[0][0] == 0
+    assert pages[0][-1] == page_size - 1
+    assert pages[1][0] == page_size
+    assert pages[1][-1] == n_records - 1

--- a/tests/test_cfasodapy.py
+++ b/tests/test_cfasodapy.py
@@ -55,7 +55,7 @@ def test_start_end(monkeypatch, offset, limit, expected_start, expected_end):
 
 def test_pages(monkeypatch):
     def mock_get_records(_, start, end):
-        return list(range(start, end + 1))
+        return list(range(start, end))
 
     monkeypatch.setattr(Query, "_get_records", mock_get_records)
     monkeypatch.setattr(Query, "_n_where_records", 100)


### PR DESCRIPTION
Right now, unpaginated queries start at `offset` and continue to `offset + limit - 1`. This is how paginated queries should also behave, but they currently ignore `offset` and `limit`.